### PR TITLE
Add rsyslog and made vm.overcommit_memory parameterizable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,9 @@ redis_max_clients: 128
 redis_max_memory: 512mb
 redis_maxmemory_policy: volatile-lru
 redis_appendfsync: everysec
+# check https://www.kernel.org/doc/Documentation/sysctl/vm.txt
+# and http://redis.io/topics/faq
+redis_overcommit_memory: 1
 #If role is slave set these values too
 redis_master_ip: 1.1.1.1
 redis_master_port: 6379

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,9 @@
 redis_bind_address: "0.0.0.0"
 redis_port: 6379
 redis_syslog_enabled: "yes"
+# Must be USER or between LOCAL0-LOCAL7.
+redis_syslog_facility: "local0"
+redis_logfile: /var/log/redis.log
 redis_databases: 16
 redis_database_save_times:
   - [900, 1]

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,4 +3,4 @@
   service: name={{ redis_service }}  state=restarted
 
 - name: restart rsyslogd
-  service: name=rsyslogd  state=restarted
+  service: name=rsyslog  state=restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,6 @@
 ---
-- name: restart redis 
-  service: name={{ redis_service }}  state=restarted 
+- name: restart redis
+  service: name={{ redis_service }}  state=restarted
+
+- name: restart rsyslogd
+  service: name=rsyslogd  state=restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,5 +2,5 @@
 - name: restart redis
   service: name={{ redis_service }}  state=restarted
 
-- name: restart rsyslogd
+- name: restart rsyslog
   service: name=rsyslog  state=restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
   - restart rsyslog
 
 - name: Set the kernel paramter for vm overcommit 
-  sysctl: name=vm.overcommit_memory value=1 state=present
+  sysctl: name=vm.overcommit_memory value={{ redis_overcommit_memory }} state=present
 
 - name: start the redis service
   service: name={{ redis_service }} state=started enabled=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,12 @@
   notify: 
    - restart redis 
 
+- name: Copy the rsyslogd configuration file for redis filter
+  template: src=rsyslogd.conf.j2 dest=/etc/rsyslog.d/redis.conf
+  when: redis_syslog_enabled == "yes"
+  notify:
+  - restart rsyslogd
+
 - name: Set the kernel paramter for vm overcommit 
   sysctl: name=vm.overcommit_memory value=1 state=present
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
   template: src=rsyslogd.conf.j2 dest=/etc/rsyslog.d/redis.conf
   when: redis_syslog_enabled == "yes"
   notify:
-  - restart rsyslogd
+  - restart rsyslog
 
 - name: Set the kernel paramter for vm overcommit 
   sysctl: name=vm.overcommit_memory value=1 state=present

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -50,7 +50,9 @@ loglevel notice
 # Specify the log file name. Also 'stdout' can be used to force
 # Redis to log on the standard output. Note that if you use standard
 # output for logging but daemonize, logs will be sent to /dev/null
-logfile /var/log/redis/redis.log
+{% if redis_syslog_enabled == "no" %}
+logfile {{ redis_logfile }}
+{% endif %}
 
 # To enable logging to the system logger, just set 'syslog-enabled' to yes,
 # and optionally update the other syslog parameters to suit your needs.
@@ -60,7 +62,7 @@ syslog-enabled {{ redis_syslog_enabled }}
 syslog-ident redis
 
 # Specify the syslog facility.  Must be USER or between LOCAL0-LOCAL7.
-syslog-facility local0
+syslog-facility {{ redis_syslog_facility }}
 
 # Set the number of databases. The default database is DB 0, you can select
 # a different one on a per-connection basis using SELECT <dbid> where

--- a/templates/rsyslogd.conf.j2
+++ b/templates/rsyslogd.conf.j2
@@ -1,3 +1,3 @@
 {{ ansible_managed }}
-if $programname == 'redis' then {{ redis_syslog_logfile }}
+if $programname == 'redis' then {{ redis_logfile }}
 & ~

--- a/templates/rsyslogd.conf.j2
+++ b/templates/rsyslogd.conf.j2
@@ -1,3 +1,3 @@
-{{ ansible_managed }}
+# {{ ansible_managed }}
 if $programname == 'redis' then {{ redis_logfile }}
 & ~

--- a/templates/rsyslogd.conf.j2
+++ b/templates/rsyslogd.conf.j2
@@ -1,0 +1,3 @@
+{{ ansible_managed }}
+if $programname == 'redis' then {{ redis_syslog_logfile }}
+& ~


### PR DESCRIPTION
tasks/main.yml:

Added task for configuring rsyslogd when redis_syslog_enabled == "yes".
templates/redis.conf.j2:

logfile is only configured if not using syslog;
Syslog facility is parametrized.
template/rsyslogd.conf.j2:

rsyslogd conf for filtering redis logs to redis_logfile.
defaults/main.yml:

Added defaults for redis_syslog_facility and redis_logfile.
handlers/main.yml:

Handler for restarting rsyslogd on conf change.
