### PR TITLE
make the vm overcommit optional

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,5 +21,6 @@ redis_appendfsync: everysec
 redis_master_ip: 1.1.1.1
 redis_master_port: 6379
 redis_master_auth: None
+redis_vm_overcommit: true
 
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,28 +3,29 @@
 - name: Add the OS specific varibles
   include_vars: "{{ ansible_os_family }}.yml"
 
-- name: Install the epel packages 
+- name: Install the epel packages
   yum: name=http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm state=present
   when: ansible_os_family == "RedHat"
 
-- name: Install the Redis packages 
+- name: Install the Redis packages
   yum: name={{ item }} state=present
   with_items: redis_redhat_pkg
   when: ansible_os_family == "RedHat"
 
-- name: Install the Redis packages 
+- name: Install the Redis packages
   apt: name={{ item }} state=present update_cache=yes
   with_items: redis_ubuntu_pkg
   environment: env
   when: ansible_os_family == "Debian"
 
-- name: Copy the redis configuration file 
+- name: Copy the redis configuration file
   template: src=redis.conf.j2 dest={{ redis_conf_dest }}
-  notify: 
-   - restart redis 
+  notify:
+   - restart redis
 
-- name: Set the kernel paramter for vm overcommit 
+- name: Set the kernel paramter for vm overcommit
   sysctl: name=vm.overcommit_memory value=1 state=present
+  when: redis_vm_overcommit
 
 - name: start the redis service
   service: name={{ redis_service }} state=started enabled=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,27 +3,27 @@
 - name: Add the OS specific varibles
   include_vars: "{{ ansible_os_family }}.yml"
 
-- name: Install the epel packages
+- name: Install the epel packages 
   yum: name=http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm state=present
   when: ansible_os_family == "RedHat"
 
-- name: Install the Redis packages
+- name: Install the Redis packages 
   yum: name={{ item }} state=present
   with_items: redis_redhat_pkg
   when: ansible_os_family == "RedHat"
 
-- name: Install the Redis packages
+- name: Install the Redis packages 
   apt: name={{ item }} state=present update_cache=yes
   with_items: redis_ubuntu_pkg
   environment: env
   when: ansible_os_family == "Debian"
 
-- name: Copy the redis configuration file
+- name: Copy the redis configuration file 
   template: src=redis.conf.j2 dest={{ redis_conf_dest }}
-  notify:
-   - restart redis
+  notify: 
+   - restart redis 
 
-- name: Set the kernel paramter for vm overcommit
+- name: Set the kernel paramter for vm overcommit 
   sysctl: name=vm.overcommit_memory value=1 state=present
   when: redis_vm_overcommit
 


### PR DESCRIPTION
Using this role on a virtual machine here, did not work, because that setting was not writeable by the root user. This was disabled by our host provider (http://serverfault.com/questions/82728/overcommitting-memory-on-an-ubuntu-server-9-10-running-on-vmware-fusion-3-0-osx/97321#97321)

For future references and Googlers:

failed: [91.250.114.88] => {"failed": true, "item": ""}
msg: checks_before failed with: key_path is not a writable file, key seems to be read only
