### PR TITLE
Allow option to not change autocommit setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ them are as follows. See the documentation for Redis for details:
 	redis_master_port: 6379           # master port
 	redis_master_auth: None           # master auth
 
+    # This isn't a redis setting, but if set to true, then the role won't try to
+    # change the kernel setting (useful for containers).
+    redis_no_vm_overcommit: false
+
 Examples
 --------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,4 +22,7 @@ redis_master_ip: 1.1.1.1
 redis_master_port: 6379
 redis_master_auth: None
 
-
+# Set this to true if you don't want to change the overcommit kernel setting.
+# (E.g. when you're using a container and you can't change kernel settings.)
+#
+redis_no_vm_overcommit: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
   notify: 
    - restart redis 
 
-- name: Set the kernel paramter for vm overcommit 
+- name: Set the kernel parameter for vm overcommit 
   sysctl: name=vm.overcommit_memory value=1 state=present
   when: redis_no_vm_overcommit == false
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,7 @@
 
 - name: Set the kernel paramter for vm overcommit 
   sysctl: name=vm.overcommit_memory value=1 state=present
+  when: redis_no_vm_overcommit == false
 
 - name: start the redis service
   service: name={{ redis_service }} state=started enabled=yes


### PR DESCRIPTION
This way we can install redis on a container (where it might not be possible to change kernel settings).

Otherwise, if you use it on a container (e.g. a proxmox/openvz container) you will get an erroe of the form:

```
TASK: [bennojoy.redis | Set the kernel paramter for vm overcommit] ************
failed: [hostname.test] => {"failed": true, "item": ""}
msg: checks_before failed with: key_path is not a writable file, key seems to be read only

FATAL: all hosts have already failed -- aborting
```

This way, the default stays the same as before, but if we want we can not have the role try to change a kernel setting.
