### PR TITLE
Fixed pidfile path on Debian/Ubuntu

### DIFF
--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -18,7 +18,7 @@ daemonize yes
 
 # When running daemonized, Redis writes a pid file in /var/run/redis.pid by
 # default. You can specify a custom pid file location here.
-pidfile /var/run/redis/redis.pid
+pidfile {{ redis_pidfile_dest }}
 
 # Accept connections on the specified port, default is 6379.
 # If port 0 is specified Redis will not listen on a TCP socket.

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,3 +2,4 @@
 
 redis_service: redis-server
 redis_conf_dest: /etc/redis/redis.conf
+redis_pidfile_dest: /var/run/redis/redis-server.pid

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,2 +1,3 @@
 redis_service: redis
 redis_conf_dest: /etc/redis.conf
+redis_pidfile_dest: /var/run/redis/redis.pid


### PR DESCRIPTION
The pidfile path specified in `templates/redis.conf.j2` doesn't match the init.d configuration on Ubuntu, so restarting/stopping/monitoring the redis service doesn't work properly.

I made a new variable so that it'll work for all supported platforms.
