### PR TITLE
Fix redis restart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Role Variables
 The variables that can be passed to this role and a brief description about
 them are as follows. See the documentation for Redis for details:
 
+  redis_server_version: 2.6.0       # The version of redis to install defaults to `latest`
 	redis_bind_address                # The network address for redis to bind to 
         redis_port: 6379                  # Port for redis server
 	redis_syslog_enabled: "yes"       # enable_syslog

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Role Variables
 The variables that can be passed to this role and a brief description about
 them are as follows. See the documentation for Redis for details:
 
-  redis_server_version: 2.6.0       # The version of redis to install defaults to `latest`
-	redis_bind_address                # The network address for redis to bind to 
-        redis_port: 6379                  # Port for redis server
+	redis_server_version: 2.6.0       # The version of redis to install defaults to `latest`
+	redis_bind_address                # The network address for redis to bind to
+	redis_port: 6379                  # Port for redis server
 	redis_syslog_enabled: "yes"       # enable_syslog
 	redis_databases: 16               # Set number of databases
 	redis_database_save_times:        # Save the DB on disk (seconds changes)
@@ -76,5 +76,3 @@ Author Information
 ------------------
 
 Benno Joy
-
-

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,22 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+MEMORY_DEFAULT = 512
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.hostname = "redis"
+
+  config.vm.provider :virtualbox do |v|
+    v.memory = MEMORY_DEFAULT
+  end
+
+  config.vm.provider :vmware_fusion do |v|
+    v.vmx["memsize"] = MEMORY_DEFAULT
+  end
+
+  config.vm.provision :shell, inline: "apt-get purge -qq -y --auto-remove chef puppet"
+  config.vm.provision :ansible do |ansible|
+    ansible.playbook = "test.yml"
+  end
+end

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,6 @@ redis_db_dir: /var/lib/redis
 redis_role: master
 redis_requirepass: false
 redis_pass: None
-redis_max_clients: 128
 redis_max_memory: 512mb
 redis_maxmemory_policy: volatile-lru
 redis_appendfsync: everysec

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,14 +13,18 @@
   when: ansible_os_family == "RedHat" and ansible_distribution != "Fedora"
         and ansible_distribution_major_version == "7"
 
-- name: Install the Redis packages 
+- name: Install the Redis packages | Redhat
   yum: name={{ item }} state=present
-  with_items: redis_redhat_pkg
+  with_items:
+    - libselinux-python
+    - "{% if redis_server_version is defined %}redis={{ redis_server_version }}{% else %}redis{% endif %}"
   when: ansible_os_family == "RedHat"
 
-- name: Install the Redis packages 
+- name: Install the Redis packages | Debian
   apt: name={{ item }} state=present update_cache=yes
-  with_items: redis_ubuntu_pkg
+  with_items:
+    - python-selinux
+    - "{% if redis_server_version is defined %}redis-server={{ redis_server_version }}{% else %}redis-server{% endif %}"
   environment: env
   when: ansible_os_family == "Debian"
 

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -18,7 +18,7 @@ daemonize yes
 
 # When running daemonized, Redis writes a pid file in /var/run/redis.pid by
 # default. You can specify a custom pid file location here.
-pidfile /var/run/redis/redis.pid
+pidfile /var/run/redis/redis-server.pid
 
 # Accept connections on the specified port, default is 6379.
 # If port 0 is specified Redis will not listen on a TCP socket.

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -178,7 +178,9 @@ requirepass {{ redis_pass }}
 # Once the limit is reached Redis will close all the new connections sending
 # an error 'max number of clients reached'.
 #
+{% if redis_max_clients is defined %}
 maxclients {{ redis_max_clients }}
+{% endif %}
 
 # Don't use more memory than the specified amount of bytes.
 # When the memory limit is reached Redis will try to remove keys

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -359,7 +359,7 @@ slowlog-max-len 1024
 # To enable VM just set 'vm-enabled' to yes, and set the following three
 # VM parameters accordingly to your needs.
 
-vm-enabled no
+# vm-enabled no
 # vm-enabled yes
 
 # This is the path of the Redis swap file. As you can guess, swap files
@@ -373,7 +373,7 @@ vm-enabled no
 # *** WARNING *** if you are using a shared hosting the default of putting
 # the swap file under /tmp is not secure. Create a dir with access granted
 # only to Redis user and configure Redis to create the swap file there.
-vm-swap-file /tmp/redis.swap
+# vm-swap-file /tmp/redis.swap
 
 # vm-max-memory configures the VM to use at max the specified amount of
 # RAM. Everything that deos not fit will be swapped on disk *if* possible, that
@@ -383,7 +383,7 @@ vm-swap-file /tmp/redis.swap
 # default, just specify the max amount of RAM you can in bytes, but it's
 # better to leave some margin. For instance specify an amount of RAM
 # that's more or less between 60 and 80% of your free RAM.
-vm-max-memory 0
+# vm-max-memory 0
 
 # Redis swap files is split into pages. An object can be saved using multiple
 # contiguous pages, but pages can't be shared between different objects.
@@ -394,7 +394,7 @@ vm-max-memory 0
 # If you use a lot of small objects, use a page size of 64 or 32 bytes.
 # If you use a lot of big objects, use a bigger page size.
 # If unsure, use the default :)
-vm-page-size 32
+# vm-page-size 32
 
 # Number of total memory pages in the swap file.
 # Given that the page table (a bitmap of free/used pages) is taken in memory,
@@ -407,7 +407,7 @@ vm-page-size 32
 #
 # It's better to use the smallest acceptable value for your application,
 # but the default is large in order to work in most conditions.
-vm-pages 134217728
+# vm-pages 134217728
 
 # Max number of VM I/O threads running at the same time.
 # This threads are used to read/write data from/to swap file, since they
@@ -418,7 +418,7 @@ vm-pages 134217728
 #
 # The special value of 0 turn off threaded I/O and enables the blocking
 # Virtual Memory implementation.
-vm-max-threads 4
+# vm-max-threads 4
 
 ############################### ADVANCED CONFIG ###############################
 

--- a/test.yml
+++ b/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  sudo: yes
+  roles:
+    - .

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,12 +3,3 @@
 env:
  RUNLEVEL: 1
 
-redis_redhat_pkg:
-  - libselinux-python
-  - redis
-
-redis_ubuntu_pkg:
-  - python-selinux
-  - redis-server
-
-  


### PR DESCRIPTION
# What

We have observed that redis doesn't restart. It actually fails silently when stopping, and again when starting. This is because the pidifle path is different in the redis config  than in the init script.
# How to review
- `vagrant up`
- `vagrant ssh`
- `ps aux|grep redis` check the pid
- `sudo /etc/init.d/redis-server restart`
- the pid should have changed
